### PR TITLE
WL-3583 Add values m.ox needs to render announcement.

### DIFF
--- a/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
+++ b/announcement-tool/tool/src/java/org/sakaiproject/announcement/entityprovider/AnnouncementEntityProviderImpl.java
@@ -678,7 +678,7 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 		@Getter @Setter private String siteId;
 		@Getter @Setter private String announcementId;
 		@Getter @Setter private String siteTitle;
-		private String channel;
+		@Getter @Setter private String channel;
 
 		/**
 		 * As we are packing these fields into the ID, we need all of them.
@@ -690,6 +690,10 @@ public class AnnouncementEntityProviderImpl extends AbstractEntityProvider imple
 			this.siteId = siteId;
 			this.channel = channel;
 			this.announcementId = announcementId;
+		}
+
+		public String getId() {
+			return String.format("%s:%s:%s", siteId, channel, announcementId);
 		}
 
 		//default sort by date ascending


### PR DESCRIPTION
In the upgrade to Sakai 10 some values had got dropped from the announcements entity broker API. These meant there wasn’t enough information to construct an entity URL for an announcement and also m.ox failed to render as properties it expected weren’t present.

Without a getId() all the entity\* values don’t get generated.
