### PR TITLE
WL-1026 : announcements made on a .anon site should be public by default

### DIFF
--- a/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -1045,7 +1045,7 @@ public class AnnouncementAction extends PagedResourceActionII
 							}
 							else if (view.equals(VIEW_MODE_PUBLIC))
 							{
-								messages = getMessagesPublic(site, channel, null, true, state, portlet);
+								messages = getMessagesPublic(site, channel, null, true, state, portlet, isChannelPublic(channelId));
 							}
 						}
 						else
@@ -1729,7 +1729,7 @@ public class AnnouncementAction extends PagedResourceActionII
 	 * @throws PermissionException
 	 */
 	private List getMessagesPublic(Site site, AnnouncementChannel defaultChannel, Filter filter, boolean ascending,
-			AnnouncementActionState state, VelocityPortlet portlet) throws PermissionException
+	                               AnnouncementActionState state, VelocityPortlet portlet, boolean isChannelPublic) throws PermissionException
 	{
 		List messageList = getMessages(defaultChannel, filter, ascending, state, portlet);
 		List rv = new Vector();
@@ -1738,7 +1738,7 @@ public class AnnouncementAction extends PagedResourceActionII
 		{
 			AnnouncementMessage aMessage = (AnnouncementMessage) messageList.get(i);
 			String pubview = aMessage.getProperties().getProperty(ResourceProperties.PROP_PUBVIEW);
-			if (pubview != null && Boolean.valueOf(pubview).booleanValue())
+			if (isChannelPublic || (pubview != null && Boolean.valueOf(pubview).booleanValue()))
 			{
 				// public announcements
 				rv.add(aMessage);


### PR DESCRIPTION
(Not sure what happened with this code (which seems strangely familiar!)...so here it is again...)

This is to fix it so that when your site is public and you create an announcement, then when you select 'Public' in the dropdown, the announcement shows up. 

I'm using the isChannelPublic(channelId) method to determine whether a site is public or not and passing the value through  
