### PR TITLE
WL-3653 Announcements tool broken for anonymous.

### DIFF
--- a/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
+++ b/announcement-tool/tool/src/java/org/sakaiproject/announcement/tool/AnnouncementAction.java
@@ -284,7 +284,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			SecurityAdvisor advisor = new SecurityAdvisor() {
 				@Override
 				public SecurityAdvice isAllowed(String userId, String function, String reference) {
-					if (userId.equals(SessionManager.getCurrentSessionUserId()) && "annc.read".equals(function) && finalChannelReference.equals(reference)) {
+					if (userId.equals(UserDirectoryService.getCurrentUser().getId()) && "annc.read".equals(function) && finalChannelReference.equals(reference)) {
 						return SecurityAdvice.ALLOWED;
 					} else {
 						return SecurityAdvice.PASS;
@@ -384,7 +384,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			SecurityAdvisor advisor = new SecurityAdvisor() {
 				@Override
 				public SecurityAdvice isAllowed(String userId, String function, String reference) {
-					if (SessionManager.getCurrentSessionUserId().equals(userId) && "annc.read".equals(function) && reference.equals(finalRef)) {
+					if (userId.equals(UserDirectoryService.getCurrentUser().getId()) && "annc.read".equals(function) && reference.equals(finalRef)) {
 						return SecurityAdvice.ALLOWED;
 					} else {
 						return SecurityAdvice.PASS;
@@ -1626,7 +1626,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			SecurityAdvisor advisor = new SecurityAdvisor() {
 				@Override
 				public SecurityAdvice isAllowed(String userId, String function, String reference) {
-					if (SessionManager.getCurrentSessionUserId().equals(userId) && "annc.read".equals(function) && reference.equals(finalChannelReference)) {
+					if (userId.equals(UserDirectoryService.getCurrentUser().getId()) && "annc.read".equals(function) && reference.equals(finalChannelReference)) {
 						return SecurityAdvice.ALLOWED;
 					} else {
 						return SecurityAdvice.PASS;
@@ -2357,7 +2357,7 @@ public class AnnouncementAction extends PagedResourceActionII
 			SecurityAdvisor advisor = new SecurityAdvisor() {
 				@Override
 				public SecurityAdvice isAllowed(String userId, String function, String reference) {
-					if (userId.equals(SessionManager.getCurrentSessionUserId()) && "annc.read".equals(function)
+					if (userId.equals(UserDirectoryService.getCurrentUser().getId()) && "annc.read".equals(function)
 						&& (finalMessageReference.equals(reference) || finalChannelReference.equals(reference))) {
 						return SecurityAdvice.ALLOWED;
 					} else {


### PR DESCRIPTION
Some recent changes mean that the announcement tool is broken for the anonymous user as when there isn’t anyone logged in the user ID returned from the session manager is null which is then compared with the current user ID which for the anonymous user is an empty string. The user directory service will return an empty string for the anonymous user.
